### PR TITLE
Fix: Atom with comment character needed quotes

### DIFF
--- a/ST23AK#1.kicad_mod
+++ b/ST23AK#1.kicad_mod
@@ -1,7 +1,7 @@
-(module ST23AK#1 (layer F.Cu)
+(module "ST23AK#1" (layer F.Cu)
   (at 0 0)
   (attr smd)
-  (fp_text reference ST23AK#1 (at 0 0) (layer F.SilkS)
+  (fp_text reference "ST23AK#1" (at 0 0) (layer F.SilkS)
     (effects (font (size 0.762 0.635) (thickness 0.127)))
   )
   (fp_text value Val** (at 0 0) (layer F.SilkS) hide


### PR DESCRIPTION
Just something small that I noticed while learning about the format.
